### PR TITLE
Add staticcheck to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.21.0
+        go-version: "1.21.0"
 
     - name: test
       run: go test -v ./
+
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: "1.21.0"
+
+    - uses: dominikh/staticcheck-action@v1.3.0
+      with:
+        install-go: false
+        version: "2023.1.5"


### PR DESCRIPTION
* Adds the standalone [staticcheck github action](https://github.com/dominikh/staticcheck-action)
* Quote the go-version string for setup-go because yaml will misinterpret unquoted lines and pull incorrect versions of go
* Bump setup-go from v3 to v4