### PR TITLE
Remove TimeoutHandler; set our own timeout

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -321,6 +321,8 @@ func makeTCH(url string, s3Service *s3.Client) tileCachingHandler {
 
 		cacheGroup: &singleflight.Group{},
 
+		fullRequestTimeout: 10 * time.Second,
+
 		requestsMetric:     prometheus.NewCounterVec(prometheus.CounterOpts{Help: "foo", Name: "ctile_requests"}, []string{"result", "source"}),
 		partialTiles:       prometheus.NewCounter(prometheus.CounterOpts{Name: "ctile_partial_tiles"}),
 		singleFlightShared: prometheus.NewCounter(prometheus.CounterOpts{Name: "ctile_singleflight_shared"}),


### PR DESCRIPTION
TimeoutHandler runs the inner handler on a separate goroutine, so it can guarantee returning within a certain time limit even if the inner handler goes past that limit. This has the unfortunate side effect that panics from the inner handler need to be sent to the outer handler by a channel and re-panicked. But re-panicking loses the original stack trace information, which makes panics very hard to diagnose.

For our purposes, we are confident that the time-consuming components will obey the context timeout, so it suffices to just set the timeout and not run the inner handler on a separate goroutine.