### PR TITLE
Make entries immutable

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,12 +112,12 @@ func (p pastTheEndError) Error() string {
 	return "requested range is past the end of the log"
 }
 
-// TrimForDisplay takes a set of entries corresponding to `tile`, and returns a new
+// trimForDisplay takes a set of entries corresponding to `tile`, and returns a new
 // object suitable for a request for entries in the range [start, end).
 //
 // This does not mutate the original object. It is suitable for calling when the set
 // of entries represents a partial tile.
-func (e *entries) TrimForDisplay(start, end int64, tile tile) (*entries, error) {
+func (e *entries) trimForDisplay(start, end int64, tile tile) (*entries, error) {
 	if start < tile.start || start >= tile.end || end <= start || len(e.Entries) > int(tile.size) {
 		return nil, fmt.Errorf("internal inconsistency: start = %d, end = %d, tile = %v, len(e.Entries) = %d", start, end, tile, len(e.Entries))
 	}
@@ -326,7 +326,7 @@ func (tch *tileCachingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("X-Source", string(source))
 
-	contents, err = contents.TrimForDisplay(start, end, tile)
+	contents, err = contents.trimForDisplay(start, end, tile)
 	if err != nil {
 		if errors.As(err, &pastTheEndError{}) {
 			tch.requestsMetric.WithLabelValues("error", "ct_log_past_end").Inc()

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTrimForDisplay(t *testing.T) {
+	entries := &entries{
+		Entries: []entry{
+			{},
+			{},
+			{},
+		},
+	}
+	_, err := entries.TrimForDisplay(1, 2, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "internal inconsistency") {
+		t.Errorf("expected internal inconsistency error, got %s", err)
+	}
+
+	_, err = entries.TrimForDisplay(999, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "internal inconsistency") {
+		t.Errorf("expected internal inconsistency error, got %s", err)
+	}
+
+	_, err = entries.TrimForDisplay(1000, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "internal inconsistency") {
+		t.Errorf("expected internal inconsistency error, got %s", err)
+	}
+
+	_, err = entries.TrimForDisplay(10, 20, tile{start: 10, end: 12, size: 2, logURL: "http://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "internal inconsistency") {
+		t.Errorf("expected internal inconsistency error, got %s", err)
+	}
+
+	_, err = entries.TrimForDisplay(15, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err == nil {
+		t.Fatal("expected error, got none")
+	}
+	if !strings.Contains(err.Error(), "past the end of the log") {
+		t.Errorf("expected 'past the end of the log' error, got %s", err)
+	}
+
+	e, err := entries.TrimForDisplay(10, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("expected success, got %s", err)
+	}
+	if len(e.Entries) != 3 {
+		t.Errorf("expected 3 entries got %d", len(entries.Entries))
+	}
+
+	e, err = entries.TrimForDisplay(11, 12, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("expected success, got %s", err)
+	}
+	if len(e.Entries) != 1 {
+		t.Errorf("expected 1 entry got %d", len(entries.Entries))
+	}
+
+	e, err = entries.TrimForDisplay(12, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	if err != nil {
+		t.Fatalf("expected success, got %s", err)
+	}
+	if len(e.Entries) != 1 {
+		t.Errorf("expected 1 entry got %d", len(entries.Entries))
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -13,7 +13,7 @@ func TestTrimForDisplay(t *testing.T) {
 			{},
 		},
 	}
-	_, err := entries.TrimForDisplay(1, 2, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	_, err := entries.trimForDisplay(1, 2, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
@@ -21,7 +21,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected internal inconsistency error, got %s", err)
 	}
 
-	_, err = entries.TrimForDisplay(999, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	_, err = entries.trimForDisplay(999, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
@@ -29,7 +29,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected internal inconsistency error, got %s", err)
 	}
 
-	_, err = entries.TrimForDisplay(1000, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	_, err = entries.trimForDisplay(1000, 1000, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
@@ -37,7 +37,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected internal inconsistency error, got %s", err)
 	}
 
-	_, err = entries.TrimForDisplay(10, 20, tile{start: 10, end: 12, size: 2, logURL: "http://example.com"})
+	_, err = entries.trimForDisplay(10, 20, tile{start: 10, end: 12, size: 2, logURL: "http://example.com"})
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
@@ -45,7 +45,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected internal inconsistency error, got %s", err)
 	}
 
-	_, err = entries.TrimForDisplay(15, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	_, err = entries.trimForDisplay(15, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err == nil {
 		t.Fatal("expected error, got none")
 	}
@@ -53,7 +53,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected 'past the end of the log' error, got %s", err)
 	}
 
-	e, err := entries.TrimForDisplay(10, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	e, err := entries.trimForDisplay(10, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err != nil {
 		t.Fatalf("expected success, got %s", err)
 	}
@@ -61,7 +61,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected 3 entries got %d", len(entries.Entries))
 	}
 
-	e, err = entries.TrimForDisplay(11, 12, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	e, err = entries.trimForDisplay(11, 12, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err != nil {
 		t.Fatalf("expected success, got %s", err)
 	}
@@ -69,7 +69,7 @@ func TestTrimForDisplay(t *testing.T) {
 		t.Errorf("expected 1 entry got %d", len(entries.Entries))
 	}
 
-	e, err = entries.TrimForDisplay(12, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
+	e, err = entries.trimForDisplay(12, 20, tile{start: 10, end: 20, size: 10, logURL: "http://example.com"})
 	if err != nil {
 		t.Fatalf("expected success, got %s", err)
 	}


### PR DESCRIPTION
This fixes a race condition when concurrent requests share a singleflight response. Previously we mutated the `contents.Entries` field to adjust for the user's actual requested range. This is always a race condition; sometimes it also resulted in a panic (index out of range), when one goroutine shortened the slice and another tried to access it.