### PR TITLE
integration: Remove dangling container and container names

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -134,11 +134,14 @@ func TestIntegration(t *testing.T) {
 	}
 	s3Service := s3.NewFromConfig(cfg)
 
-	_, err = s3Service.CreateBucket(context.Background(), &s3.CreateBucketInput{
-		Bucket: aws.String("bucket"),
-	})
+	_, err = s3Service.HeadBucket(context.TODO(), &s3.HeadBucketInput{Bucket: aws.String("bucket")})
 	if err != nil {
-		t.Fatal(err)
+		_, err = s3Service.CreateBucket(context.Background(), &s3.CreateBucketInput{
+			Bucket: aws.String("bucket"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	ctile := tileCachingHandler{


### PR DESCRIPTION
Fixes a flaky minio error when running `go test -v ./...` in rapid succession due to a bucket already existing.

```
$ go test -v ./...
minio is up
=== RUN   TestIntegration
    integration_test.go:141: operation error S3: CreateBucket, https response error StatusCode: 409, RequestID: 1782341B6096C63C, HostID: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8, BucketAlreadyOwnedByYou: 
--- FAIL: TestIntegration (0.00s)
```