### PR TITLE
Error if bucket name contains scheme

### DIFF
--- a/main.go
+++ b/main.go
@@ -469,6 +469,8 @@ func main() {
 		*s3prefix = *logURL
 	}
 
+	*s3bucket = strings.TrimPrefix(*s3bucket, "s3://")
+
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -469,7 +469,9 @@ func main() {
 		*s3prefix = *logURL
 	}
 
-	*s3bucket = strings.TrimPrefix(*s3bucket, "s3://")
+	if strings.HasPrefix(*s3bucket, "s3://") {
+		*s3bucket = strings.TrimPrefix(*s3bucket, "s3://")
+	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -469,8 +469,9 @@ func main() {
 		*s3prefix = *logURL
 	}
 
-	if strings.HasPrefix(*s3bucket, "s3://") {
-		*s3bucket = strings.TrimPrefix(*s3bucket, "s3://")
+	_, err := url.ParseRequestURI(*s3bucket)
+	if err == nil {
+		log.Fatal("scheme provided for s3-bucket, but should not be")
 	}
 
 	cfg, err := config.LoadDefaultConfig(context.Background())


### PR DESCRIPTION
Return an error to the operator if the supplied bucket name contains a scheme e.g. `s3://bucketname`, `whatever://bucketname`, `http://bucketname`, etc.  The [aws-sdk-go s3 service](https://docs.aws.amazon.com/sdk-for-go/api/service/s3/#New) examples show the bucket name without the scheme. This change does not enforce that a bucket is properly named according to the [s3 docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) nor do I think it should. Instead that work should be left to the aws-sdk-go. This is just a nice ease of use improvement for myself because I didn't know what an appropriate bucket name was.