### PR TITLE
Set Content-Type to application/json

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -179,6 +179,7 @@ func TestIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
+	expectHeader(t, headers, "Content-Type", "application/json")
 	expectHeader(t, headers, "X-Source", "CT log")
 
 	if len(twoEntriesA.Entries) != 2 {
@@ -215,6 +216,7 @@ func TestIntegration(t *testing.T) {
 		t.Error(err)
 	}
 
+	expectHeader(t, headers, "Content-Type", "application/json")
 	expectHeader(t, headers, "X-Source", "S3")
 	expectAndResetMetric(t, ctile.requestsMetric, 1, "success", "s3_get")
 

--- a/main.go
+++ b/main.go
@@ -442,6 +442,7 @@ func (tch *tileCachingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("X-Response-Len", fmt.Sprintf("%d", len(contents.Entries)))
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
 	encoder := json.NewEncoder(w)


### PR DESCRIPTION
These endpoints return JSON data, and other CT servers return application/json.

Fixes #27 